### PR TITLE
Desestructuring the data from the API response body

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-editor-js": "^1.9.0",
     "react-hook-form": "^7.10.1",
     "react-icons": "^4.1.0",
+    "react-query": "^3.18.1",
     "rich-markdown-editor": "^11.1.6",
     "yup": "^0.32.9"
   },

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -71,7 +71,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         path: '/'
       });
 
-      api.defaults.headers.Authorization = `Bearer ${token}`;
+      api.defaults.headers['x-access-token'] = token;
 
       setUser({
         email,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,12 +4,17 @@ import { theme } from '../styles/theme';
 
 import { AuthProvider } from '../contexts/AuthContext';
 
+import { QueryClientProvider } from 'react-query';
+import { queryClient } from '../services/queryClient';
+
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <AuthProvider>
-      <ChakraProvider resetCSS theme={theme}>
-        <Component {...pageProps} />
-      </ChakraProvider>
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <ChakraProvider resetCSS theme={theme}>
+          <Component {...pageProps} />
+        </ChakraProvider>
+      </AuthProvider>
+    </QueryClientProvider>
   )
 }

--- a/src/pages/senders/index.tsx
+++ b/src/pages/senders/index.tsx
@@ -1,12 +1,35 @@
 import Head from 'next/head'
-import { Box, Flex, Heading, HStack, Table, Tag, Tbody, Td, Text, Th, Thead, Tr, Link } from '@chakra-ui/react'
+import { Box, Flex, Heading, HStack, Table, Icon, Tbody, Td, Text, Th, Thead, Tr, Link } from '@chakra-ui/react'
 
 import { Sidebar } from '../../components/Sidebar'
 import { Header } from '../../components/Header'
 import { Button } from '../../components/Button'
 import { withSSRAuth } from '../../utils/withSSRAuth'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+
+import { RiSearch2Line } from 'react-icons/ri';
+
+import { Input } from '../../components/Form/Input';
+import { useSenders } from '../../services/hooks/useSenders'
+
+type SearchSendersFormData = {
+  search: string;
+};
 
 export default function Senders() {
+  const [page, setPage] = useState(1)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const { register, handleSubmit } = useForm();
+
+  const { data, isLoading } = useSenders(page, searchQuery)
+
+  const handleSearchSenders: SubmitHandler<SearchSendersFormData> = async ({ search }) => {
+    setPage(1)
+    setSearchQuery(search);
+  };
+
   return (
     <Box>
       <Head>
@@ -31,6 +54,28 @@ export default function Senders() {
               <Heading size="lg" fontWeight="medium">Remetentes</Heading>
               <Text mt="1" color="gray.400">Listagem completa de remetentes</Text>
             </Box>
+
+            <Flex 
+              as="form" 
+              onSubmit={handleSubmit(handleSearchSenders)}
+            >
+              <Input
+                name="search"
+                placeholder="Search contacts"
+                {...register('search')}
+              />
+
+              <Button
+                size="lg"
+                fontSize="sm"
+                colorScheme="purple"
+                ml="2"
+                disabled={isLoading}
+                isLoading={isLoading}
+              >
+                <Icon as={RiSearch2Line} fontSize="16" />
+              </Button>
+            </Flex>
           </Flex>
 
           <Table>
@@ -42,28 +87,21 @@ export default function Senders() {
               </Tr>
             </Thead>
             <Tbody>
-              <Tr>
-                <Td>
-                  <Link color="blue.500" title="Ver detalhes">Diego Fernandes</Link>
-                </Td>
-                <Td>
-                  <Text>diego@rocketseat.team</Text>
-                </Td>
-                <Td textAlign="right">
-                  <Button colorScheme="purple" disabled size="sm" fontSize="sm">Remetente padrão</Button>
-                </Td>
-              </Tr>
-              <Tr>
-                <Td>
-                  <Link color="blue.500" title="Ver detalhes">Robson Marques</Link>
-                </Td>
-                <Td>
-                  <Text>robson@rocketseat.team</Text>
-                </Td>
-                <Td textAlign="right">
-                  <Button colorScheme="purple" size="sm" fontSize="sm">Definir como padrão</Button>
-                </Td>
-              </Tr>
+              {data?.senders.map(sender => (
+                <Tr>
+                  <Td>
+                    <Link color="blue.500" title="Ver detalhes">{sender.name}</Link>
+                  </Td>
+                  <Td>
+                    <Text>{sender.email}</Text>
+                  </Td>
+                  <Td textAlign="right">
+                    <Button colorScheme="purple" disabled={sender.isDefault} size="sm" fontSize="sm">
+                      {sender.isDefault ? 'Default template' : 'Set as default'}
+                    </Button>
+                  </Td>
+                </Tr>
+              ))}
             </Tbody>
           </Table>
 

--- a/src/pages/senders/index.tsx
+++ b/src/pages/senders/index.tsx
@@ -108,7 +108,7 @@ export default function Senders() {
             </Thead>
             <Tbody>
               {data?.senders.map(sender => (
-                <Tr>
+                <Tr key={sender.id}>
                   <Td>
                     <Link color="blue.500" title="Ver detalhes">{sender.name}</Link>
                   </Td>

--- a/src/pages/senders/index.tsx
+++ b/src/pages/senders/index.tsx
@@ -12,6 +12,9 @@ import { RiSearch2Line } from 'react-icons/ri';
 
 import { Input } from '../../components/Form/Input';
 import { useSenders } from '../../services/hooks/useSenders'
+import { useMutation } from 'react-query'
+import { api } from '../../services/api'
+import { queryClient } from '../../services/queryClient'
 
 type SearchSendersFormData = {
   search: string;
@@ -28,6 +31,23 @@ export default function Senders() {
   const handleSearchSenders: SubmitHandler<SearchSendersFormData> = async ({ search }) => {
     setPage(1)
     setSearchQuery(search);
+  };
+
+  const setDefaultSender = useMutation(
+    async (senderId: string) => {
+      const response = await api.patch(`/senders/${senderId}/set-as-default`);
+
+      return response.data;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('senders');
+      }
+    }
+  );
+
+  const handleEditSender = async (senderId: string) => {
+    await setDefaultSender.mutateAsync(senderId);
   };
 
   return (
@@ -96,7 +116,13 @@ export default function Senders() {
                     <Text>{sender.email}</Text>
                   </Td>
                   <Td textAlign="right">
-                    <Button colorScheme="purple" disabled={sender.isDefault} size="sm" fontSize="sm">
+                    <Button
+                      colorScheme="purple"
+                      disabled={sender.isDefault}
+                      size="sm"
+                      fontSize="sm"
+                      onClick={() => handleEditSender(sender.id)}
+                    >
                       {sender.isDefault ? 'Default template' : 'Set as default'}
                     </Button>
                   </Td>

--- a/src/pages/subscribers/index.tsx
+++ b/src/pages/subscribers/index.tsx
@@ -84,7 +84,7 @@ export default function Subscribers() {
               </Tr>
             </Thead>
             <Tbody>
-              {data?.contacts.map((contact, index) => (
+              {data?.contacts.map((contact) => (
                 <Tr>
                   <Td>
                     <Link color="blue.500" title="Ver detalhes">{contact.email}</Link>

--- a/src/pages/subscribers/index.tsx
+++ b/src/pages/subscribers/index.tsx
@@ -23,7 +23,7 @@ export default function Subscribers() {
 
   const { register, handleSubmit } = useForm();
 
-  const { data } = useContacts(page, searchQuery)
+  const { data, isLoading } = useContacts(page, searchQuery)
 
   const handleSearchContacts: SubmitHandler<SearchContactsFormData> = async ({ search }) => {
     setPage(1)
@@ -70,6 +70,8 @@ export default function Subscribers() {
                 fontSize="sm"
                 colorScheme="purple"
                 ml="2"
+                disabled={isLoading}
+                isLoading={isLoading}
               >
                 <Icon as={RiSearch2Line} fontSize="16" />
               </Button>

--- a/src/pages/subscribers/index.tsx
+++ b/src/pages/subscribers/index.tsx
@@ -85,7 +85,7 @@ export default function Subscribers() {
             </Thead>
             <Tbody>
               {data?.contacts.map((contact) => (
-                <Tr>
+                <Tr key={contact.id}>
                   <Td>
                     <Link color="blue.500" title="Ver detalhes">{contact.email}</Link>
                   </Td>

--- a/src/pages/subscribers/index.tsx
+++ b/src/pages/subscribers/index.tsx
@@ -1,12 +1,35 @@
 import Head from 'next/head'
-import { Box, Flex, Heading, HStack, Table, Tag, Tbody, Td, Text, Th, Thead, Tr, Link } from '@chakra-ui/react'
+import { Box, Flex, Heading, HStack, Table, Tbody, Td, Text, Th, Thead, Tr, Link, Icon } from '@chakra-ui/react'
 
 import { Sidebar } from '../../components/Sidebar'
 import { Header } from '../../components/Header'
 import { Button } from '../../components/Button'
 import { withSSRAuth } from '../../utils/withSSRAuth'
+import { useContacts } from '../../services/hooks/useContacts'
+
+import { Input } from '../../components/Form/Input';
+
+import { RiSearch2Line } from 'react-icons/ri';
+import { useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+type SearchContactsFormData = {
+  search: string;
+};
 
 export default function Subscribers() {
+  const [page, setPage] = useState(1)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const { register, handleSubmit } = useForm();
+
+  const { data } = useContacts(page, searchQuery)
+
+  const handleSearchContacts: SubmitHandler<SearchContactsFormData> = async ({ search }) => {
+    setPage(1)
+    setSearchQuery(search);
+  };
+
   return (
     <Box>
       <Head>
@@ -31,6 +54,26 @@ export default function Subscribers() {
               <Heading size="lg" fontWeight="medium">Inscritos</Heading>
               <Text mt="1" color="gray.400">Listagem completa de inscritos</Text>
             </Box>
+
+            <Flex 
+              as="form" 
+              onSubmit={handleSubmit(handleSearchContacts)}
+            >
+              <Input
+                name="search"
+                placeholder="Search contacts"
+                {...register('search')}
+              />
+
+              <Button
+                size="lg"
+                fontSize="sm"
+                colorScheme="purple"
+                ml="2"
+              >
+                <Icon as={RiSearch2Line} fontSize="16" />
+              </Button>
+            </Flex>
           </Flex>
 
           <Table>
@@ -38,28 +81,17 @@ export default function Subscribers() {
               <Tr>
                 <Th>Contato</Th>
                 <Th>Data de inscrição</Th>
-                <Th>Status</Th>
               </Tr>
             </Thead>
             <Tbody>
-              <Tr>
-                <Td>
-                  <Link color="blue.500" title="Ver detalhes">diego@rocketseat.team</Link>
-                </Td>
-                <Td color="gray.500">04 de Abril, 2021</Td>
-                <Td>
-                  <Tag colorScheme="purple">Inscrito</Tag>
-                </Td>
-              </Tr>
-              <Tr>
-                <Td>
-                  <Link color="blue.500" title="Ver detalhes">diego.schell.f@gmail.com</Link>
-                </Td>
-                <Td color="gray.500">04 de Abril, 2021</Td>
-                <Td>
-                  <Tag colorScheme="red">Cancelado</Tag>
-                </Td>
-              </Tr>
+              {data?.contacts.map((contact, index) => (
+                <Tr>
+                  <Td>
+                    <Link color="blue.500" title="Ver detalhes">{contact.email}</Link>
+                  </Td>
+                  <Td color="gray.500">{contact.createdAt}</Td>
+                </Tr>
+              ))}
             </Tbody>
           </Table>
 

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -26,7 +26,7 @@ export default function Tags() {
 
   const { data, isLoading } = useTags(page, searchQuery)
 
-  const handleSearchContacts: SubmitHandler<SearchTagsFormData> = async ({ search }) => {
+  const handleSearchTags: SubmitHandler<SearchTagsFormData> = async ({ search }) => {
     setPage(1)
     setSearchQuery(search);
   };
@@ -58,7 +58,7 @@ export default function Tags() {
 
             <Flex 
               as="form" 
-              onSubmit={handleSubmit(handleSearchContacts)}
+              onSubmit={handleSubmit(handleSearchTags)}
             >
               <Input
                 name="search"

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -1,12 +1,36 @@
 import Head from 'next/head'
-import { Box, Flex, Heading, HStack, Table, Tag, Tbody, Td, Text, Th, Thead, Tr, Link } from '@chakra-ui/react'
+import { Box, Flex, Heading, HStack, Table, Icon, Tbody, Td, Text, Th, Thead, Tr, Link } from '@chakra-ui/react'
 
 import { Sidebar } from '../../components/Sidebar'
 import { Header } from '../../components/Header'
 import { Button } from '../../components/Button'
 import { withSSRAuth } from '../../utils/withSSRAuth'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+
+import { RiSearch2Line } from 'react-icons/ri';
+
+import { Input } from '../../components/Form/Input';
+import { useTags } from '../../services/hooks/useTags'
+
+
+type SearchTagsFormData = {
+  search: string;
+};
 
 export default function Tags() {
+  const [page, setPage] = useState(1)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const { register, handleSubmit } = useForm();
+
+  const { data, isLoading } = useTags(page, searchQuery)
+
+  const handleSearchContacts: SubmitHandler<SearchTagsFormData> = async ({ search }) => {
+    setPage(1)
+    setSearchQuery(search);
+  };
+
   return (
     <Box>
       <Head>
@@ -31,6 +55,28 @@ export default function Tags() {
               <Heading size="lg" fontWeight="medium">Tags</Heading>
               <Text mt="1" color="gray.400">Listagem completa de tags</Text>
             </Box>
+
+            <Flex 
+              as="form" 
+              onSubmit={handleSubmit(handleSearchContacts)}
+            >
+              <Input
+                name="search"
+                placeholder="Search contacts"
+                {...register('search')}
+              />
+
+              <Button
+                size="lg"
+                fontSize="sm"
+                colorScheme="purple"
+                ml="2"
+                disabled={isLoading}
+                isLoading={isLoading}
+              >
+                <Icon as={RiSearch2Line} fontSize="16" />
+              </Button>
+            </Flex>
           </Flex>
 
           <Table>
@@ -41,22 +87,16 @@ export default function Tags() {
               </Tr>
             </Thead>
             <Tbody>
-              <Tr>
-                <Td>
-                  <Link color="blue.500" title="Ver detalhes">Ignite ReactJS 1.0</Link>
-                </Td>
-                <Td>
-                  <Text>1.200</Text>
-                </Td>
-              </Tr>
-              <Tr>
-                <Td>
-                  <Link color="blue.500" title="Ver detalhes">Ignite ReactJS 2.0</Link>
-                </Td>
-                <Td>
-                  <Text>1.200</Text>
-                </Td>
-              </Tr>
+              {data?.tags.map(tag => (
+                <Tr>
+                  <Td>
+                    <Link color="blue.500" title="Ver detalhes">{tag.title}</Link>
+                  </Td>
+                  <Td>
+                    <Text>{tag.subscribersCount}</Text>
+                  </Td>
+                </Tr>
+              ))}
             </Tbody>
           </Table>
 

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -88,7 +88,7 @@ export default function Tags() {
             </Thead>
             <Tbody>
               {data?.tags.map(tag => (
-                <Tr>
+                <Tr key={tag.id}>
                   <Td>
                     <Link color="blue.500" title="Ver detalhes">{tag.title}</Link>
                   </Td>

--- a/src/pages/templates/index.tsx
+++ b/src/pages/templates/index.tsx
@@ -1,12 +1,35 @@
 import Head from 'next/head'
-import { Box, Flex, Heading, HStack, Table, Tag, Tbody, Td, Text, Th, Thead, Tr, Link } from '@chakra-ui/react'
+import { Box, Flex, Heading, HStack, Table, Tbody, Td, Text, Th, Thead, Tr, Link, Icon } from '@chakra-ui/react'
+import { RiSearch2Line } from 'react-icons/ri';
 
 import { Sidebar } from '../../components/Sidebar'
 import { Header } from '../../components/Header'
 import { Button } from '../../components/Button'
 import { withSSRAuth } from '../../utils/withSSRAuth'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { useTemplates } from '../../services/hooks/useTemplates'
+
+import { Input } from '../../components/Form/Input';
+
+type SearchTemplatesFormData = {
+  search: string;
+};
 
 export default function Templates() {
+  const [page, setPage] = useState(1)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const { register, handleSubmit } = useForm();
+
+  const { data } = useTemplates(page, searchQuery)
+
+  const handleSearchContacts: SubmitHandler<SearchTemplatesFormData> = async ({ search }) => {
+    setPage(1)
+    setSearchQuery(search);
+  };
+
+
   return (
     <Box>
       <Head>
@@ -31,6 +54,26 @@ export default function Templates() {
               <Heading size="lg" fontWeight="medium">Templates</Heading>
               <Text mt="1" color="gray.400">Listagem completa de templates</Text>
             </Box>
+
+            <Flex 
+              as="form" 
+              onSubmit={handleSubmit(handleSearchContacts)}
+            >
+              <Input
+                name="search"
+                placeholder="Search templates"
+                {...register('search')}
+              />
+
+              <Button
+                size="lg"
+                fontSize="sm"
+                colorScheme="purple"
+                ml="2"
+              >
+                <Icon as={RiSearch2Line} fontSize="16" />
+              </Button>
+            </Flex>
           </Flex>
 
           <Table>
@@ -41,22 +84,19 @@ export default function Templates() {
               </Tr>
             </Thead>
             <Tbody>
-              <Tr>
-                <Td>
-                  <Link color="blue.500" title="Ver detalhes">Default</Link>
-                </Td>
-                <Td textAlign="right">
-                  <Button colorScheme="purple" disabled size="sm" fontSize="sm">Template padrão</Button>
-                </Td>
-              </Tr>
-              <Tr>
-                <Td>
-                  <Link color="blue.500" title="Ver detalhes">Template Ignite</Link>
-                </Td>
-                <Td textAlign="right">
-                  <Button colorScheme="purple" size="sm" fontSize="sm">Definir como padrão</Button>
-                </Td>
-              </Tr>
+              {data?.templates.map(template => (
+                <Tr>
+                  <Td>
+                    <Link color="blue.500" title="Ver detalhes">{template.title}</Link>
+                  </Td>
+                
+                  <Td textAlign="right">
+                    <Button colorScheme="purple" disabled={template.isDefault} size="sm" fontSize="sm">
+                      {template.isDefault ? 'Default template' : 'Set as default'}
+                    </Button>
+                  </Td>
+                </Tr>
+              ))}
             </Tbody>
           </Table>
 

--- a/src/pages/templates/index.tsx
+++ b/src/pages/templates/index.tsx
@@ -87,7 +87,7 @@ export default function Templates() {
             </Thead>
             <Tbody>
               {data?.templates.map(template => (
-                <Tr>
+                <Tr key={template.id}>
                   <Td>
                     <Link color="blue.500" title="Ver detalhes">{template.title}</Link>
                   </Td>

--- a/src/pages/templates/index.tsx
+++ b/src/pages/templates/index.tsx
@@ -22,7 +22,7 @@ export default function Templates() {
 
   const { register, handleSubmit } = useForm();
 
-  const { data } = useTemplates(page, searchQuery)
+  const { data, isLoading } = useTemplates(page, searchQuery)
 
   const handleSearchContacts: SubmitHandler<SearchTemplatesFormData> = async ({ search }) => {
     setPage(1)
@@ -70,6 +70,8 @@ export default function Templates() {
                 fontSize="sm"
                 colorScheme="purple"
                 ml="2"
+                disabled={isLoading}
+                isLoading={isLoading}
               >
                 <Icon as={RiSearch2Line} fontSize="16" />
               </Button>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -7,7 +7,7 @@ const cookies = parseCookies();
 export const api = axios.create({
   baseURL: 'http://localhost:3333/',
   headers: {
-    Authorization: `Bearer ${cookies['umbriel-admin.token']}`
+    'x-access-token': cookies['umbriel-admin.token']
   }
 });
 

--- a/src/services/hooks/useContacts.ts
+++ b/src/services/hooks/useContacts.ts
@@ -10,6 +10,7 @@ type Contact = {
 
 type GetContactsReponse = {
   contacts: Contact[];
+  totalCount: number;
 };
 
 export async function getContacts(page: number, searchQuery?: string): Promise<GetContactsReponse>  {
@@ -20,7 +21,7 @@ export async function getContacts(page: number, searchQuery?: string): Promise<G
     }
   });
 
-  const { data } = response;
+  const { data, totalCount } = response.data;
 
   const contacts = data.map(contact => {
     return {
@@ -38,7 +39,8 @@ export async function getContacts(page: number, searchQuery?: string): Promise<G
   });
 
   return {
-    contacts
+    contacts,
+    totalCount
   };
 }
 

--- a/src/services/hooks/useContacts.ts
+++ b/src/services/hooks/useContacts.ts
@@ -1,0 +1,50 @@
+import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { api } from '../api';
+
+type Contact = {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string;
+};
+
+type GetContactsReponse = {
+  contacts: Contact[];
+};
+
+export async function getContacts(page: number, searchQuery?: string): Promise<GetContactsReponse>  {
+  const response = await api.get('/contacts/search', {
+    params: {
+      page,
+      query: searchQuery
+    }
+  });
+
+  const { data } = response;
+
+  const contacts = data.map(contact => {
+    return {
+      id: contact.id,
+      name: contact.name,
+      email: contact.email,
+      createdAt: new Date(contact.created_at).toLocaleDateString('en-us', {
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      })
+    };
+  });
+
+  return {
+    contacts
+  };
+}
+
+export function useContacts(page: number = 1, searchQuery?: string, options?: UseQueryOptions) {
+  return useQuery(['contacts', [page, searchQuery]], () => getContacts(page, searchQuery), {
+    staleTime: 1000 * 60 * 1,
+    ...options
+  }) as UseQueryResult<GetContactsReponse, unknown> ;
+}

--- a/src/services/hooks/useSenders.ts
+++ b/src/services/hooks/useSenders.ts
@@ -1,0 +1,46 @@
+import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { api } from '../api';
+
+type Sender = {
+  id: string;
+  name: string;
+  email: string;
+  isValidated: boolean;
+  isDefault: boolean;
+};
+
+type GetSendersReponse = {
+  senders: Sender[];
+};
+
+export async function getSenders(page: number, searchQuery?: string): Promise<GetSendersReponse>  {
+  const response = await api.get('/senders/search', {
+    params: {
+      page,
+      query: searchQuery
+    }
+  });
+
+  const { data } = response;
+
+  const senders = data.map(sender => {
+    return {
+      id: sender.id,
+      name: sender.name,
+      email: sender.email,
+      isDefault: sender.isDefault,
+      isValidated: sender.isValidated,
+    };
+  });
+
+  return {
+    senders
+  };
+}
+
+export function useSenders(page: number = 1, searchQuery?: string, options?: UseQueryOptions) {
+  return useQuery(['senders', [page, searchQuery]], () => getSenders(page, searchQuery), {
+    staleTime: 1000 * 60 * 1,
+    ...options
+  }) as UseQueryResult<GetSendersReponse, unknown> ;
+}

--- a/src/services/hooks/useSenders.ts
+++ b/src/services/hooks/useSenders.ts
@@ -11,7 +11,7 @@ type Sender = {
 
 type GetSendersReponse = {
   senders: Sender[];
-  totalCount: string;
+  totalCount: number;
 };
 
 export async function getSenders(page: number, searchQuery?: string): Promise<GetSendersReponse>  {

--- a/src/services/hooks/useSenders.ts
+++ b/src/services/hooks/useSenders.ts
@@ -11,6 +11,7 @@ type Sender = {
 
 type GetSendersReponse = {
   senders: Sender[];
+  totalCount: string;
 };
 
 export async function getSenders(page: number, searchQuery?: string): Promise<GetSendersReponse>  {
@@ -21,7 +22,7 @@ export async function getSenders(page: number, searchQuery?: string): Promise<Ge
     }
   });
 
-  const { data } = response;
+  const { data, totalCount } = response.data;
 
   const senders = data.map(sender => {
     return {
@@ -34,7 +35,8 @@ export async function getSenders(page: number, searchQuery?: string): Promise<Ge
   });
 
   return {
-    senders
+    senders,
+    totalCount
   };
 }
 

--- a/src/services/hooks/useTags.ts
+++ b/src/services/hooks/useTags.ts
@@ -9,6 +9,7 @@ type Tag = {
 
 type GetTagsReponse = {
   tags: Tag[];
+  totalCount: number;
 };
 
 export async function getTags(page: number, searchQuery?: string): Promise<GetTagsReponse>  {
@@ -19,7 +20,7 @@ export async function getTags(page: number, searchQuery?: string): Promise<GetTa
     }
   });
 
-  const { data } = response;
+  const { data, totalCount } = response.data;
 
   const tags = data.map(tag => {
     return {
@@ -30,7 +31,8 @@ export async function getTags(page: number, searchQuery?: string): Promise<GetTa
   });
 
   return {
-    tags
+    tags,
+    totalCount
   };
 }
 

--- a/src/services/hooks/useTags.ts
+++ b/src/services/hooks/useTags.ts
@@ -1,0 +1,42 @@
+import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { api } from '../api';
+
+type Tag = {
+  id: string;
+  title: string;
+  subscribersCount: number;
+};
+
+type GetTagsReponse = {
+  tags: Tag[];
+};
+
+export async function getTags(page: number, searchQuery?: string): Promise<GetTagsReponse>  {
+  const response = await api.get('/tags/search', {
+    params: {
+      page,
+      query: searchQuery
+    }
+  });
+
+  const { data } = response;
+
+  const tags = data.map(tag => {
+    return {
+      id: tag.id,
+      title: tag.title,
+      subscribersCount: tag.subscribersCount
+    };
+  });
+
+  return {
+    tags
+  };
+}
+
+export function useTags(page: number = 1, searchQuery?: string, options?: UseQueryOptions) {
+  return useQuery(['tags', [page, searchQuery]], () => getTags(page, searchQuery), {
+    staleTime: 1000 * 60 * 1,
+    ...options
+  }) as UseQueryResult<GetTagsReponse, unknown> ;
+}

--- a/src/services/hooks/useTemplates.ts
+++ b/src/services/hooks/useTemplates.ts
@@ -1,0 +1,42 @@
+import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { api } from '../api';
+
+type Template = {
+  id: string;
+  title: string;
+  isDefault: boolean;
+};
+
+type GetTemplatesReponse = {
+  templates: Template[];
+};
+
+export async function getTemplates(page: number, searchQuery?: string): Promise<GetTemplatesReponse>  {
+  const response = await api.get('/templates/search', {
+    params: {
+      page,
+      query: searchQuery
+    }
+  });
+
+  const { data } = response;
+
+  const templates = data.map(template => {
+    return {
+      id: template.id,
+      title: template.title,
+      isDefault: template.isDefault
+    };
+  });
+
+  return {
+    templates
+  };
+}
+
+export function useTemplates(page: number = 1, searchQuery?: string, options?: UseQueryOptions) {
+  return useQuery(['templates', [page, searchQuery]], () => getTemplates(page, searchQuery), {
+    staleTime: 1000 * 60 * 1,
+    ...options
+  }) as UseQueryResult<GetTemplatesReponse, unknown> ;
+}

--- a/src/services/hooks/useTemplates.ts
+++ b/src/services/hooks/useTemplates.ts
@@ -9,6 +9,7 @@ type Template = {
 
 type GetTemplatesReponse = {
   templates: Template[];
+  totalCount: number;
 };
 
 export async function getTemplates(page: number, searchQuery?: string): Promise<GetTemplatesReponse>  {
@@ -19,7 +20,7 @@ export async function getTemplates(page: number, searchQuery?: string): Promise<
     }
   });
 
-  const { data } = response;
+  const { data, totalCount } = response.data;
 
   const templates = data.map(template => {
     return {
@@ -30,7 +31,8 @@ export async function getTemplates(page: number, searchQuery?: string): Promise<
   });
 
   return {
-    templates
+    templates,
+    totalCount
   };
 }
 

--- a/src/services/queryClient.ts
+++ b/src/services/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from 'react-query';
+
+export const queryClient = new QueryClient();

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,7 +100,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.5":
+"@babel/runtime@^7.10.5", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
   integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
@@ -1161,6 +1161,11 @@ base64-js@^1.0.2, base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -1204,6 +1209,20 @@ braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -1744,6 +1763,11 @@ detect-node-es@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.0.0.tgz#c0318b9e539a5256ca780dd9575c9345af05b8ed"
   integrity sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg==
 
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -2109,6 +2133,18 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
+glob@^7.1.3:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.1.5:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -2409,6 +2445,11 @@ jest-worker@24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2541,6 +2582,14 @@ markdown-it@^10.0.0:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -2559,6 +2608,11 @@ merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -2609,6 +2663,13 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoclone@^0.2.1:
   version "0.2.1"
@@ -2777,6 +2838,11 @@ object-assign@4.1.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -3341,6 +3407,15 @@ react-portal@^4.2.1:
   dependencies:
     prop-types "^15.5.8"
 
+react-query@^3.18.1:
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.18.1.tgz#893b5475a7b4add099e007105317446f7a2cd310"
+  integrity sha512-17lv3pQxU9n+cB5acUv0/cxNTjo9q8G+RsedC6Ax4V9D8xEM7Q5xf9xAbCPdEhDrrnzPjTls9fQEABKRSi7OJA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -3425,6 +3500,11 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
@@ -3474,6 +3554,13 @@ rich-markdown-editor@^11.1.6:
     slugify "^1.4.0"
     smooth-scroll-into-view-if-needed "^1.1.27"
     typescript "3.7.5"
+
+rimraf@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -4006,6 +4093,14 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR aim's to fix all the routes that used the data directly from the `response.data`.

Now we are returning `response.data.data` and also `response.data.totalCount` to count all the items.